### PR TITLE
Add basic booking API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,14 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/abhinav/bookmyshow/controller/BookMyShowController.java
+++ b/src/main/java/com/abhinav/bookmyshow/controller/BookMyShowController.java
@@ -1,0 +1,57 @@
+package com.abhinav.bookmyshow.controller;
+
+import com.abhinav.bookmyshow.model.City;
+import com.abhinav.bookmyshow.model.Event;
+import com.abhinav.bookmyshow.model.Show;
+import com.abhinav.bookmyshow.model.Ticket;
+import com.abhinav.bookmyshow.service.BookingService;
+import com.abhinav.bookmyshow.service.CityService;
+import com.abhinav.bookmyshow.service.EventService;
+import com.abhinav.bookmyshow.service.ShowService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/")
+public class BookMyShowController {
+    private final CityService cityService;
+    private final EventService eventService;
+    private final ShowService showService;
+    private final BookingService bookingService;
+
+    public BookMyShowController(CityService cityService,
+                                EventService eventService,
+                                ShowService showService,
+                                BookingService bookingService) {
+        this.cityService = cityService;
+        this.eventService = eventService;
+        this.showService = showService;
+        this.bookingService = bookingService;
+    }
+
+    @GetMapping("/cities")
+    public List<City> getCities() {
+        return cityService.listCities();
+    }
+
+    @GetMapping("/events/{cityId}")
+    public List<Event> getEvents(@PathVariable Long cityId) {
+        return eventService.getEventsByCity(cityId);
+    }
+
+    @GetMapping("/shows/{eventId}")
+    public List<Show> getShows(@PathVariable Long eventId) {
+        return showService.getShowsByEvent(eventId);
+    }
+
+    @PostMapping("/book/{showId}")
+    public ResponseEntity<Ticket> book(@PathVariable Long showId) {
+        Ticket ticket = bookingService.book(showId);
+        if (ticket == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(ticket);
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/model/City.java
+++ b/src/main/java/com/abhinav/bookmyshow/model/City.java
@@ -1,0 +1,19 @@
+package com.abhinav.bookmyshow.model;
+
+public class City {
+    private Long id;
+    private String name;
+
+    public City(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/model/Event.java
+++ b/src/main/java/com/abhinav/bookmyshow/model/Event.java
@@ -1,0 +1,25 @@
+package com.abhinav.bookmyshow.model;
+
+public class Event {
+    private Long id;
+    private String name;
+    private Long cityId;
+
+    public Event(Long id, String name, Long cityId) {
+        this.id = id;
+        this.name = name;
+        this.cityId = cityId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getCityId() {
+        return cityId;
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/model/Show.java
+++ b/src/main/java/com/abhinav/bookmyshow/model/Show.java
@@ -1,0 +1,43 @@
+package com.abhinav.bookmyshow.model;
+
+import java.time.LocalDateTime;
+
+public class Show {
+    private Long id;
+    private Long eventId;
+    private LocalDateTime time;
+    private int capacity;
+    private int booked;
+
+    public Show(Long id, Long eventId, LocalDateTime time, int capacity) {
+        this.id = id;
+        this.eventId = eventId;
+        this.time = time;
+        this.capacity = capacity;
+        this.booked = 0;
+    }
+
+    public synchronized boolean bookSeat() {
+        if (booked < capacity) {
+            booked++;
+            return true;
+        }
+        return false;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public int getRemainingSeats() {
+        return capacity - booked;
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/model/Ticket.java
+++ b/src/main/java/com/abhinav/bookmyshow/model/Ticket.java
@@ -1,0 +1,19 @@
+package com.abhinav.bookmyshow.model;
+
+public class Ticket {
+    private Long id;
+    private Long showId;
+
+    public Ticket(Long id, Long showId) {
+        this.id = id;
+        this.showId = showId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getShowId() {
+        return showId;
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/repository/CityRepository.java
+++ b/src/main/java/com/abhinav/bookmyshow/repository/CityRepository.java
@@ -1,0 +1,29 @@
+package com.abhinav.bookmyshow.repository;
+
+import com.abhinav.bookmyshow.model.City;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class CityRepository {
+    private final Map<Long, City> cities = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        cities.put(1L, new City(1L, "Delhi"));
+        cities.put(2L, new City(2L, "Mumbai"));
+    }
+
+    public List<City> findAll() {
+        return new ArrayList<>(cities.values());
+    }
+
+    public City findById(Long id) {
+        return cities.get(id);
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/repository/EventRepository.java
+++ b/src/main/java/com/abhinav/bookmyshow/repository/EventRepository.java
@@ -1,0 +1,33 @@
+package com.abhinav.bookmyshow.repository;
+
+import com.abhinav.bookmyshow.model.Event;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+public class EventRepository {
+    private final Map<Long, Event> events = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        events.put(1L, new Event(1L, "Rock Concert", 1L));
+        events.put(2L, new Event(2L, "Movie Premiere", 1L));
+        events.put(3L, new Event(3L, "Comedy Show", 2L));
+    }
+
+    public List<Event> findAllByCity(Long cityId) {
+        return events.values().stream()
+                .filter(e -> e.getCityId().equals(cityId))
+                .collect(Collectors.toList());
+    }
+
+    public Event findById(Long id) {
+        return events.get(id);
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/repository/ShowRepository.java
+++ b/src/main/java/com/abhinav/bookmyshow/repository/ShowRepository.java
@@ -1,0 +1,33 @@
+package com.abhinav.bookmyshow.repository;
+
+import com.abhinav.bookmyshow.model.Show;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+public class ShowRepository {
+    private final Map<Long, Show> shows = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        shows.put(1L, new Show(1L, 1L, LocalDateTime.now().plusHours(1), 2));
+        shows.put(2L, new Show(2L, 1L, LocalDateTime.now().plusHours(3), 2));
+        shows.put(3L, new Show(3L, 2L, LocalDateTime.now().plusHours(2), 2));
+    }
+
+    public List<Show> findAllByEvent(Long eventId) {
+        return shows.values().stream()
+                .filter(s -> s.getEventId().equals(eventId))
+                .collect(Collectors.toList());
+    }
+
+    public Show findById(Long id) {
+        return shows.get(id);
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/repository/TicketRepository.java
+++ b/src/main/java/com/abhinav/bookmyshow/repository/TicketRepository.java
@@ -1,0 +1,25 @@
+package com.abhinav.bookmyshow.repository;
+
+import com.abhinav.bookmyshow.model.Ticket;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class TicketRepository {
+    private final Map<Long, Ticket> tickets = new HashMap<>();
+    private long idCounter = 1;
+
+    public synchronized Ticket save(Long showId) {
+        Ticket ticket = new Ticket(idCounter++, showId);
+        tickets.put(ticket.getId(), ticket);
+        return ticket;
+    }
+
+    public List<Ticket> findAll() {
+        return new ArrayList<>(tickets.values());
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/service/BookingService.java
+++ b/src/main/java/com/abhinav/bookmyshow/service/BookingService.java
@@ -1,0 +1,26 @@
+package com.abhinav.bookmyshow.service;
+
+import com.abhinav.bookmyshow.model.Show;
+import com.abhinav.bookmyshow.model.Ticket;
+import com.abhinav.bookmyshow.repository.ShowRepository;
+import com.abhinav.bookmyshow.repository.TicketRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookingService {
+    private final ShowRepository showRepository;
+    private final TicketRepository ticketRepository;
+
+    public BookingService(ShowRepository showRepository, TicketRepository ticketRepository) {
+        this.showRepository = showRepository;
+        this.ticketRepository = ticketRepository;
+    }
+
+    public Ticket book(Long showId) {
+        Show show = showRepository.findById(showId);
+        if (show != null && show.bookSeat()) {
+            return ticketRepository.save(showId);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/service/CityService.java
+++ b/src/main/java/com/abhinav/bookmyshow/service/CityService.java
@@ -1,0 +1,20 @@
+package com.abhinav.bookmyshow.service;
+
+import com.abhinav.bookmyshow.model.City;
+import com.abhinav.bookmyshow.repository.CityRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CityService {
+    private final CityRepository cityRepository;
+
+    public CityService(CityRepository cityRepository) {
+        this.cityRepository = cityRepository;
+    }
+
+    public List<City> listCities() {
+        return cityRepository.findAll();
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/service/EventService.java
+++ b/src/main/java/com/abhinav/bookmyshow/service/EventService.java
@@ -1,0 +1,24 @@
+package com.abhinav.bookmyshow.service;
+
+import com.abhinav.bookmyshow.model.Event;
+import com.abhinav.bookmyshow.repository.EventRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class EventService {
+    private final EventRepository eventRepository;
+
+    public EventService(EventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    public List<Event> getEventsByCity(Long cityId) {
+        return eventRepository.findAllByCity(cityId);
+    }
+
+    public Event getEvent(Long id) {
+        return eventRepository.findById(id);
+    }
+}

--- a/src/main/java/com/abhinav/bookmyshow/service/ShowService.java
+++ b/src/main/java/com/abhinav/bookmyshow/service/ShowService.java
@@ -1,0 +1,24 @@
+package com.abhinav.bookmyshow.service;
+
+import com.abhinav.bookmyshow.model.Show;
+import com.abhinav.bookmyshow.repository.ShowRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ShowService {
+    private final ShowRepository showRepository;
+
+    public ShowService(ShowRepository showRepository) {
+        this.showRepository = showRepository;
+    }
+
+    public List<Show> getShowsByEvent(Long eventId) {
+        return showRepository.findAllByEvent(eventId);
+    }
+
+    public Show getShow(Long id) {
+        return showRepository.findById(id);
+    }
+}

--- a/src/test/java/com/abhinav/bookmyshow/BookingFlowTests.java
+++ b/src/test/java/com/abhinav/bookmyshow/BookingFlowTests.java
@@ -1,0 +1,39 @@
+package com.abhinav.bookmyshow;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BookingFlowTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void listCitiesAndEventsAndBook() throws Exception {
+        mockMvc.perform(get("/cities"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(greaterThanOrEqualTo(1))));
+
+        mockMvc.perform(get("/events/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(greaterThanOrEqualTo(1))));
+
+        mockMvc.perform(get("/shows/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(greaterThanOrEqualTo(1))));
+
+        mockMvc.perform(post("/book/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.showId", is(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- add model classes for City, Event, Show and Ticket
- create simple in-memory repositories
- implement services for listing and booking
- expose REST endpoints for cities, events, shows and ticket booking
- add unit test covering booking flow

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688440f331b8832e90e530d3136cd226